### PR TITLE
Implemented: Spinner in timezone modal so users can see that data is being fetched

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
   "Failed": "Failed",
   "Failed to update some jobs": "Failed to update some jobs",
   "Failed to schedule service, hence other jobs are not updated": "Failed to schedule service, hence other jobs are not updated",
+  "Fetching time zones": "Fetching time zones",
   "Go to Launchpad": "Go to Launchpad",
   "Go to OMS": "Go to OMS",
   "History": "History",

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -76,22 +76,6 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-light-tint: #f5f6f9;
 }
 
-.empty-state {
-  max-width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-}
-
-.empty-state > img {
-  object-fit: contain;
-}
-
-.empty-state > p {
-  text-align: center; 
-}
 
 @media (prefers-color-scheme: dark) {
   /*
@@ -327,6 +311,23 @@ hr {
 
 .sort > div > :first-child{
   border-bottom: var(--border-medium);
+}
+
+.empty-state {
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
+.empty-state > img {
+  object-fit: contain;
+}
+
+.empty-state > p {
+  text-align: center;
 }
 
 @media (min-width: 991px) {

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -76,6 +76,23 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-light-tint: #f5f6f9;
 }
 
+.empty-state {
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
+.empty-state > img {
+  object-fit: contain;
+}
+
+.empty-state > p {
+  text-align: center; 
+}
+
 @media (prefers-color-scheme: dark) {
   /*
    * Dark Colors

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -14,9 +14,15 @@
   </ion-header>
 
   <ion-content class="ion-padding">
-    <!-- Empty state -->
-    <div class="empty-state" v-if="filteredTimeZones.length === 0">
-      <p>{{ $t("No time zone found")}}</p>
+     <!-- Empty state -->
+    <div class="empty-state" v-if="isLoading">
+      <ion-item lines="none">
+        <ion-spinner color="secondary" name="crescent" slot="start" />
+        {{ $t("Fetching time zones") }}
+      </ion-item>
+    </div>
+    <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+      <p>{{ $t("No time zone found") }}</p>
     </div>
 
     <!-- Timezones -->
@@ -54,6 +60,7 @@ import {
   IonRadioGroup,
   IonRadio,
   IonSearchbar,
+  IonSpinner,
   IonTitle,
   IonToolbar,
   modalController,
@@ -81,6 +88,7 @@ export default defineComponent({
     IonRadioGroup,
     IonRadio,
     IonSearchbar,
+    IonSpinner,
     IonTitle,
     IonToolbar 
   },
@@ -89,7 +97,8 @@ export default defineComponent({
       queryString: '',
       filteredTimeZones: [],
       timeZones: [],
-      timeZoneId: ''
+      timeZoneId: '',
+      isLoading: true
     }
   },
   methods: {
@@ -129,6 +138,7 @@ export default defineComponent({
       });
     },
     async getAvailableTimeZones() {
+      this.isLoading = true;
       UserService.getAvailableTimeZones().then((resp: any) => {
         if(resp.status === 200 && !hasError(resp)) {
           // We are filtering valid the timeZones coming with response here
@@ -137,6 +147,7 @@ export default defineComponent({
           });
           this.findTimeZone();
         }
+        //this.isLoading = false;
       })
     },
     selectSearchBarText(event: any) {

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -36,7 +36,7 @@
         </ion-radio-group>
       </ion-list>
     </div>
-    
+
     <ion-fab vertical="bottom" horizontal="end" slot="fixed">
       <ion-fab-button :disabled="!timeZoneId" @click="saveAlert">
         <ion-icon :icon="save" />
@@ -98,7 +98,7 @@ export default defineComponent({
       filteredTimeZones: [],
       timeZones: [],
       timeZoneId: '',
-      isLoading: true
+      isLoading: false
     }
   },
   methods: {
@@ -147,7 +147,7 @@ export default defineComponent({
           });
           this.findTimeZone();
         }
-        //this.isLoading = false;
+        this.isLoading = false;
       })
     },
     selectSearchBarText(event: any) {


### PR DESCRIPTION


### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Closes #

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Spinner is added to show that the timezones are being fetched from the API. It is indicating to the user that the data is loading.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot 2024-01-06 093850](https://github.com/hotwax/inventory-count/assets/83332530/348205af-8a58-4280-81f0-4ef0d4f035c7)

 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)