### PR TITLE
Implemented: Added API endpoint for the auto completion of solr facets

### DIFF
--- a/drl/ProductFacilityRuleTemplate.drl.ftl
+++ b/drl/ProductFacilityRuleTemplate.drl.ftl
@@ -22,7 +22,6 @@
     </#if>
     <#if !facilityIds?has_content>
       <#assign facilityGroupConditions = ec.entity.find("co.hotwax.rule.RuleCondition").condition("ruleId", decisionRule.ruleId).condition("conditionTypeEnumId", "ENTCT_ATP_FAC_GROUPS").list()!>
-        <#assign facilityGroupIds = []>
         <#assign includedFacilityGroupIds = []>
         <#assign excludedFacilityGroupIds = []>
         <#if facilityGroupConditions?has_content>

--- a/service/atp.rest.xml
+++ b/service/atp.rest.xml
@@ -56,6 +56,9 @@
             <method type="get"><entity name="co.hotwax.product.feature.ProductFeatureAndType" operation="list"/></method>
         </resource>
     </resource>
+    <resource name="solrFacets">
+        <method type="get"><service name="co.hotwax.common.CommonServices.autoComplete#SolrFacet"/></method>
+    </resource>
     <resource name="checkOmsConnection">
         <method type="get"><service name="co.hotwax.common.CommonServices.checkOmsConnection"/></method>
     </resource>

--- a/service/atp.rest.xml
+++ b/service/atp.rest.xml
@@ -77,6 +77,7 @@
     </resource>
     <resource name="ruleGroups">
         <method type="post"><entity name="co.hotwax.rule.RuleGroup" operation="store"/></method>
+        <method type="get"><entity name="co.hotwax.rule.RuleGroup" operation="list" masterName="default"/></method>
         <id name="ruleGroupId">
             <method type="get"><entity name="co.hotwax.rule.RuleGroup" operation="one" masterName="default"/></method>
             <method type="post"><entity name="co.hotwax.rule.RuleGroup" operation="store" masterName="default"/></method>

--- a/service/co/hotwax/common/CommonServices.xml
+++ b/service/co/hotwax/common/CommonServices.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://moqui.org/xsd/service-definition-3.xsd">
+    <service verb="run" noun="OmsApi" type="interface">
+        <in-parameters>
+            <parameter name="token"/>
+            <parameter name="omsBaseUrl"/>
+        </in-parameters>
+    </service>
+    <service verb="autoComplete" noun="OmsSolrFacetApi" type="interface">
+        <in-parameters>
+            <parameter name="facetToSelect" type="String"/>
+            <parameter name="coreName" type="String"/>
+            <parameter name="docType" type="String"/>
+            <parameter name="searchfield" type="String"/>
+            <parameter name="jsonQuery" type="String"/>
+            <parameter name="noConditionFind" type="String"/>
+            <parameter name="limit" type="String"/>
+            <parameter name="q" type="String"/>
+            <parameter name="term" type="String"/>
+            <parameter name="offset" type="Integer"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="facetResponse"/>
+        </out-parameters>
+    </service>
+    <service  verb="autoComplete" noun="OmsSolrFacet" type="remote-rest" location="${omsBaseUrl}/api/AutoCompleteSolrFacet?token=${token}" method="post" transaction-timeout="3600">
+        <implements service="co.hotwax.common.CommonServices.run#OmsApi"/>
+        <implements service="co.hotwax.common.CommonServices.autoComplete#OmsSolrFacetApi"/>
+    </service>
+    <service verb="autoComplete" noun="SolrFacet" transaction-timeout="3600">
+        <implements service="co.hotwax.common.CommonServices.autoComplete#OmsSolrFacetApi"/>
+        <actions>
+            <script>
+                omsBaseUrl = co.hotwax.common.DecisionRuleHelper.getOmsInstanceUrl(ec.ecfi);
+                token = co.hotwax.common.DecisionRuleHelper.getOmsJwtToken(ec.ecfi);
+            </script>
+            <if condition="!token">
+                <return error="true" message="Unable to generate oms token, check JWT configuration"/>
+            </if>
+            <if condition="!omsBaseUrl">
+                <return error="true" message="OMS base url not found"/>
+            </if>
+            <service-call name="co.hotwax.common.CommonServices.autoComplete#OmsSolrFacet" transaction-timeout="3600"
+                          in-map="context + [omsBaseUrl: omsBaseUrl, token: token]" transaction="force-new"
+                          out-map="facetResponse"/>
+        </actions>
+    </service>
+
+</services>


### PR DESCRIPTION
Done following -
1) Added API endpoint for the auto completion of solr facets. This will be used for the auto completion of product tags and product features. 
2) Also enhanced rule template to prepare facility list based on the included and excluded facility groups.
3) Added API endPoint to fetch rule groups based on type and product store. 