### PR TITLE
Fixed: Provided full path when specifying member entity name (#1).

### DIFF
--- a/entity/ProductFacilityViewEntities.xml
+++ b/entity/ProductFacilityViewEntities.xml
@@ -68,8 +68,8 @@ under the License.
     </view-entity>
 
     <view-entity entity-name="FacilityGroupAndMember" package="co.hotwax.facility">
-        <member-entity entity-alias="FG" entity-name="FacilityGroup"/>
-        <member-entity entity-alias="FGM" entity-name="FacilityGroupMember" join-from-alias="FG">
+        <member-entity entity-alias="FG" entity-name="org.apache.ofbiz.product.facility.FacilityGroup"/>
+        <member-entity entity-alias="FGM" entity-name="org.apache.ofbiz.product.facility.FacilityGroupMember" join-from-alias="FG">
             <key-map field-name="facilityGroupId"/>
         </member-entity>
         <member-entity entity-alias="FAC" entity-name="Facility" join-from-alias="FGM">


### PR DESCRIPTION
Fixed: Provided full path when specifying member entity name (#1).