### PR TITLE
Fixed: Corrected result map name to set ruleGroupRunId correctly while updating RuleGroupRun after running the rule group (#1).

### DIFF
--- a/service/co/hotwax/rule/DecisionRuleServices.xml
+++ b/service/co/hotwax/rule/DecisionRuleServices.xml
@@ -110,7 +110,7 @@
             </if>
             <service-call name="create#co.hotwax.rule.RuleGroupRun" transaction="force-new" ignore-error="true"
                     in-map="[ruleGroupId:ruleGroupId, productStoreId: productStoreId, startDate:ec.user.nowTimestamp]"
-                    out-map="ruleGroupRunResult"/>
+                    out-map="ruleGroupResult"/>
 
             <service-call name="co.hotwax.product.ProductFacilityServices.run#ExportProductFacilityDetail"
                     in-map="[ruleGroupId:ruleGroupId, productStoreId: productStoreId, systemMessageRemoteId: systemMessageRemoteId]"
@@ -131,8 +131,8 @@
             </script>
 
             <service-call name="update#co.hotwax.rule.RuleGroupRun" transaction="force-new" ignore-error="true"
-                    in-map="[ruleGroupRunId:ruleGroupRunResult.ruleGroupRunId, ruleGroupRunResult:ruleGroupRunResult, hasError:hasError, endDate:ec.user.nowTimestamp]"
-                    out-map="ruleGroupRunResult"/>
+                    in-map="[ruleGroupRunId:ruleGroupResult.ruleGroupRunId, ruleGroupRunResult:ruleGroupRunResult, hasError:hasError, endDate:ec.user.nowTimestamp]"
+                    out-map="ruleGroupResult"/>
 
             <message type="success">Finished rule group execution for ${ruleGroup.groupName} [${ruleGroupId}] rule group.</message>
         </actions>


### PR DESCRIPTION
Fixed: Corrected result map name to set ruleGroupRunId correctly while updating RuleGroupRun after running the rule group (#1).