### PR TITLE
Updated: Preserved Formatting of Group Descriptions in Cards(#334)

### DIFF
--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -26,7 +26,7 @@
                 <div>
                   <ion-card-subtitle class="overline">{{ channel.facilityGroupId }}</ion-card-subtitle>
                   <ion-card-title>{{ channel.facilityGroupName }}</ion-card-title>
-                  <ion-card-subtitle>{{ channel.description }}</ion-card-subtitle>
+                  <ion-card-subtitle v-html="channel.description.replace(/(?:\n|\n)/g, '<br />')"></ion-card-subtitle>
                 </div>
               </ion-card-header>
   


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 #334 

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
-  Uses v-html with replace to show descriptions with correct line breaks using <br /> tags.
- Ensures descriptions in Ionic cards are visually consistent and easy to read with formatted line breaks.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before - 
![image](https://github.com/hotwax/available-to-promise/assets/89250683/6f226cb2-2199-407e-919b-9d2416284bde)

After - 
![Screenshot from 2024-07-08 15-51-51](https://github.com/hotwax/available-to-promise/assets/89250683/885a0011-ad36-4f99-9826-da1547242b19)


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/available-to-promise#contribution-guideline)