### PR TITLE
Fixed: custom order limit alert opening issue in case of undefined orderlimit (#378)

### DIFF
--- a/src/components/OrderLimitPopover.vue
+++ b/src/components/OrderLimitPopover.vue
@@ -65,7 +65,7 @@ async function showOrderLimitAlert(header: string, message: string, showInput: b
       name: "setLimit",
       placeholder: translate("Order fulfillment capacity"),
       type: "number",
-      value: props.fulfillmentOrderLimit.toString(),
+      value: props.fulfillmentOrderLimit?.toString(),
       min: 0
     }] : [],
     buttons: [{


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 #378 

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added optional chaining to pre filling orderlimit in custom order limit card.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/available-to-promise#contribution-guideline)